### PR TITLE
readme and state name changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,56 @@
 # Overview
 
-This interface layer handles the communication between the Apache Zookeeper unit members.
+This interface layer handles the communication among Apache Zookeeper peers.
 
 
 # Usage
 
 ## Peers
 
-This interface allows the peers of the Zookeeper deployment to become aware of each other.
-This interface layer will set the following states, as appropriate:
+This interface allows the peers of the Zookeeper deployment to be aware of
+each other. This interface layer will set the following states, as appropriate:
 
-  * `{relation_name}.relating` A new member/unit in the Zookeeper service is present.
-    The Zookeeper charm has to make a call to `get_nodes()` in order get the list of tuples with the unit ids and their IP.
-    When a unit joins the set of peers, the interface makes sure that there is no `{relation_name}.departing` state set in the conversation. 
-    A call to `dismiss_relating()` will clean the states in the conversation between the peers in this way the reactive framework will not notify the charm for the joining of the same peer again.
-    
-    
-  * `{relation_name}.departing` A member/unit in the Zookeeper service has departed.
-    The Zookeeper charm has to make a call to `get_nodes()` in order get the IP of the departing nodes.
-    A call to `dismiss_departing()` will clean the states in the conversation between the peers and dismiss the relation. 
-    
-    
-For example, let's say that a new unit is added to the Zookeeper service deployment. 
-The Zookeeper layer should handle the state of `{relation_name}.relate` like this:
+  * `{relation_name}.joined` A new peer in the Zookeeper service has
+  joined. The Zookeeper charm should call `get_nodes()` to get
+  a list of tuples with unit ids and IP addresses for quorum members.
+
+    * When a unit joins the set of peers, the interface ensures there
+    is no `{relation_name}.departed` state set in the conversation.
+
+    * A call to `dismiss_joined()` will remove the `joined` state in the
+    peer conversation so this charm can react to subsequent peers joining.
+
+
+  * `{relation_name}.departed` A peer in the Zookeeper service has
+  departed. The Zookeeper charm should call `get_nodes()` to get
+  a list of tuples with unit ids and IP addresses for remaining quorum members.
+
+    * When a unit leaves the set of peers, the interface ensures there
+    is no `{relation_name}.joined` state set in the conversation.
+
+    * A call to `dismiss_departed()` will remove the `departed` state in the
+    peer conversation so this charm can react to subsequent peers departing.
+
+
+For example, let's say that a peer is added to the Zookeeper service
+deployment. The Zookeeper charm should handle the new peer like this:
 
 ```python
-@when('zookeeper.installed', 'instance.related')
-def quorum_incresed(instances):
-    nodes = instances.get_nodes()
-    instances.dismiss_joining()
-    zk = Zookeeper(dist_config())
-    zk.increase_quorum(nodes)
+@when('zookeeper.installed', 'zkpeer.joined')
+def quorum_add(zkpeer):
+    nodes = zkpeer.get_nodes()
+    increase_quorum(nodes)
+    zkpeer.dismiss_joined()
 ```
 
-In similar fashion, when a peer departs:
-```
-@when('zookeeper.installed', 'instance.departing')
-def quorum_decreased(instances):
-    nodes = instances.get_nodes()
-    instances.dismiss_departing()
-    zk = Zookeeper(dist_config())
-    zk.decrease_quorum(nodes)
+Similarly, when a peer departs:
+
+```python
+@when('zookeeper.installed', 'zkpeer.departed')
+def quorum_remove(zkpeer):
+    nodes = zkpeer.get_nodes()
+    decrease_quorum(nodes)
+    zkpeer.dismiss_departed()
 ```
 
 

--- a/interface.yaml
+++ b/interface.yaml
@@ -1,4 +1,4 @@
 name: zookeeper-quorum
 summary: Interface used by the Apache Zookeeper quorum members
 version: 1
-maintainer: "Big Data Team <bigdata@lists.ubuntu.com>"
+maintainer: "Juju Big Data <bigdata@lists.ubuntu.com>"

--- a/peers.py
+++ b/peers.py
@@ -13,30 +13,28 @@
 from charms.reactive import RelationBase, hook, scopes
 
 
-class QuorumPeers(RelationBase):
-    # Every unit connecting will get the same information
+class ZookeeperPeers(RelationBase):
     scope = scopes.UNIT
-    relation_name = 'zookeeper-quorum'
 
-    @hook('{peers:zookeeper-quorum}-relation-{joined}')
-    def changed(self):
+    @hook('{peers:zookeeper-quorum}-relation-joined')
+    def joined(self):
         conv = self.conversation()
-        conv.set_state('{relation_name}.relating')
-        conv.remove_state('{relation_name}.departing')
+        conv.remove_state('{relation_name}.departed')
+        conv.set_state('{relation_name}.joined')
 
-    @hook('{peers:zookeeper-quorum}-relation-{departed}')
+    @hook('{peers:zookeeper-quorum}-relation-departed')
     def departed(self):
         conv = self.conversation()
-        conv.remove_state('{relation_name}.relating')
-        conv.set_state('{relation_name}.departing')
+        conv.remove_state('{relation_name}.joined')
+        conv.set_state('{relation_name}.departed')
 
-    def dismiss_departing(self):
+    def dismiss_departed(self):
         for conv in self.conversations():
-            conv.remove_state('{relation_name}.departing')
+            conv.remove_state('{relation_name}.departed')
 
-    def dismiss_relating(self):
+    def dismiss_joined(self):
         for conv in self.conversations():
-            conv.remove_state('{relation_name}.relating')
+            conv.remove_state('{relation_name}.joined')
 
     def get_nodes(self):
         nodes = []


### PR DESCRIPTION
- replace 'relating' with 'joined'
- replace 'departing' with 'departed'
- Update README with state name changes and clarifying verbiage
