### PR TITLE
Added hooks in interface layer to facilitate a rolling restart.

### DIFF
--- a/peers.py
+++ b/peers.py
@@ -10,7 +10,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from charms.reactive import RelationBase, hook, scopes
+import json
+from charms.leadership import leader_get
+from charms.reactive import RelationBase, hook, scopes, is_state
 
 
 class ZookeeperPeers(RelationBase):
@@ -28,6 +30,19 @@ class ZookeeperPeers(RelationBase):
         conv.remove_state('{relation_name}.joined')
         conv.set_state('{relation_name}.departed')
 
+    @hook('{peers:zookeeper-quorum}-relation-changed')
+    def toggle_restarted(self):
+        if not is_state('leadership.is_leader'):
+            # Only the leader should set the zkpeer.restarted state
+            # (only the leader will manage to clear the state).
+            return
+        nonce = leader_get('restart_nonce')
+        toggle = self.get_remote('restarted.{}'.format(nonce))
+        if toggle:
+            toggle = json.loads(toggle)
+
+        self.toggle_state('{relation_name}.restarted', toggle)
+
     def dismiss_departed(self):
         for conv in self.conversations():
             conv.remove_state('{relation_name}.departed')
@@ -42,3 +57,33 @@ class ZookeeperPeers(RelationBase):
             nodes.append((conv.scope, conv.get_remote('private-address')))
 
         return nodes
+
+    def set_zk_leader(self):
+        '''
+        Inform peers that the unit that calls this method is the Zookeeper leader.
+
+        Note that Zookeeper tracks leadership separately from juju;
+        the Zookeeper leader is not necessarily the Juju leader.
+
+        '''
+        for conv in self.conversations():
+            conv.set_remote('is_zk_leader', True)
+
+    def find_zk_leader(self):
+        '''
+        Find the private address of the leader.
+
+        '''
+        for conv in self.conversations():
+            if conv.get_remote('is_zk_leader'):
+                return conv.get_remote('private_address')
+
+    def inform_restart(self):
+        '''
+        Inform our peers that we have restarted, usually as part of a
+        rolling restart.
+
+        '''
+        for conv in self.conversations():
+            nonce = leader_get('restart_nonce')
+            conv.set_remote('restarted.{}'.format(nonce), json.dumps(True))


### PR DESCRIPTION
Allows Zookeeper to perform an automagic rolling restart, rather than
requiring an ops person to do the restart manually.

@juju-solutions/bigdata 
