### PR TITLE
Add interface for zkpeer-relation-changed.

### DIFF
--- a/peers.py
+++ b/peers.py
@@ -30,6 +30,11 @@ class ZookeeperPeers(RelationBase):
         conv.remove_state('{relation_name}.joined')
         conv.set_state('{relation_name}.departed')
 
+    @hook('{peers:zookeeper-quorum}-relation-changed')
+    def changed(self):
+        conv = self.conversation()
+        conv.set_state('{relation_name}.changed')
+
     def dismiss_departed(self):
         for conv in self.conversations():
             conv.remove_state('{relation_name}.departed')
@@ -37,6 +42,10 @@ class ZookeeperPeers(RelationBase):
     def dismiss_joined(self):
         for conv in self.conversations():
             conv.remove_state('{relation_name}.joined')
+
+    def dismiss_changed(self):
+        for conv in self.conversations():
+            conv.remove_state('{relation_name}.changed')
 
     def get_nodes(self):
         nodes = []


### PR DESCRIPTION
This change adds the interface needed to define a zkpeer-relation-changed
hook. This is needed to make sure we update all the server.[\d]=<ip_address>
lines in config file if the relation information changes, either manually or automatically.
A PR against bigtop will follow this patchset to add the rest of the code.

Signed-off-by: José Pekkarinen <jose.pekkarinen@canonical.com>